### PR TITLE
Changed install order.

### DIFF
--- a/apis/requirements.txt
+++ b/apis/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==1.2.0
 numpy==1.7.0
+matplotlib==1.2.0
 requests==1.1.0
 tablib==0.9.11


### PR DESCRIPTION
Numpy needs to be installed before MatPlotLib
