### PR TITLE
fixed placement of sudo command

### DIFF
--- a/website/_posts/Begin/2013-09-29-Setup-your-machine.md
+++ b/website/_posts/Begin/2013-09-29-Setup-your-machine.md
@@ -61,8 +61,8 @@ i686-apple-darwin11-llvm-gcc-4.2: no input files
 [pip][9], stands for “python install python”, is a tool for installing and managing Python packages. Within your Terminal application, use the following commands (ignore the leading `$` as that is your terminal prompt) for downloading & installing. It may prompt you for your computer login password.
 
 ```bash
-$ sudo curl -O http://python-distribute.org/distribute_setup.py | python
-$ sudo curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
+$ curl http://python-distribute.org/distribute_setup.py | sudo python
+$ curl https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo python
 $ pip
 Usage: pip COMMAND [OPTIONS]
 You must give a command (use "pip help" to see a list of commands)
@@ -125,8 +125,8 @@ To test if you have either GCC or clang, type `$ gcc` or `$ clang` into your ter
 [pip][9], stands for “python install python”, is a tool for installing and managing Python packages. Within your Terminal application, use the following commands (ignore the leading `$` as that is your terminal prompt) for downloading & installing. It may prompt you for your computer login password.
 
 ```bash
-$ sudo curl -O http://python-distribute.org/distribute_setup.py | python
-$ sudo curl -O https://raw.github.com/pypa/pip/master/contrib/get-pip.py | python
+$ curl http://python-distribute.org/distribute_setup.py | sudo python
+$ curl https://raw.github.com/pypa/pip/master/contrib/get-pip.py | sudo python
 $ pip
 Usage: pip COMMAND [OPTIONS]
 You must give a command (use "pip help" to see a list of commands)


### PR DESCRIPTION
The sudo was giving root privilidges to curl rather than python (which needed
them). Secondly, the -O option was saving the file to disk rather than passing
it into python on stdin.
