### PR TITLE
Updated title, description, location and price XPath selectors

### DIFF
--- a/scrape/living_social/scraper_app/spiders/livingsocial_spider.py
+++ b/scrape/living_social/scraper_app/spiders/livingsocial_spider.py
@@ -24,13 +24,13 @@ class LivingSocialSpider(BaseSpider):
     start_urls = ["http://www.livingsocial.com/cities/15-san-francisco"]
 
     deals_list_xpath = '//li[@dealid]'
-    item_fields = {'title': './/a/div[@class="deal-bottom"]/h3[@itemprop]/text()',
+    item_fields = {'title': './/a/div[@class="deal-details"]/h3[@itemprop]/text()',
                    'link': './/a/@href',
-                   'description': './/a/div[@class="deal-bottom"]/p/text()',
+                   'description': './/a/div[@class="deal-details"]/p/[@class="description"]/text()',
                    'category': './/a/div[@class="deal-top"]/div[@class="deal-category"]/span/text()',
-                   'location': './/a/div[@class="deal-top"]/ul[@class="unstyled deal-info"]/li/text()',
+                   'location': './/a/div[@class="deal-details"]/p/[@class="location"]/text()',
                    'original_price': './/a/div[@class="deal-bottom"]/ul[@class="unstyled deal-info"]/li[@class="deal-original"]/del/text()',
-                   'price': './/a/div[@class="deal-bottom"]/ul[@class="unstyled deal-info"]/li[@class="deal-price"]/text()'}
+                   'price': './/a/div[@class="deal-price"]/text()'}
 
     def parse(self, response):
         """


### PR DESCRIPTION
Recently worked through the scrapy tutorial and found that the XPath selectors weren't matching the structure of the Living social site I was looking at. If there was a different page that I should have been using, disregard. I've updated the title, description, location and price. I did not find original price or category.
