### PR TITLE
Typo, "worry about his as"->"worry about this as"

### DIFF
--- a/website/_site/dataviz/part-0/index.html
+++ b/website/_site/dataviz/part-0/index.html
@@ -117,7 +117,7 @@
 </pre></div>
 </td></tr></table></div></div>
 <ul>
-<li><strong>NOTE</strong> Sometimes, matplotlib is finicky as well. If you are on a Mac and &ldquo;pip install matplotlib&rdquo; did not work, you are probably missing the supporting packages freetype2 and libpng. Windows users do not need to worry about his as these packages are already included in the standard matplotlib Windows installers. For Mac users, below are detailed instructions on how to install them. 
+<li><strong>NOTE</strong> Sometimes, matplotlib is finicky as well. If you are on a Mac and &ldquo;pip install matplotlib&rdquo; did not work, you are probably missing the supporting packages freetype2 and libpng. Windows users do not need to worry about this as these packages are already included in the standard matplotlib Windows installers. For Mac users, below are detailed instructions on how to install them. 
 Note that libpng has a dependency on zlib library, so we have to install that first. So in total we install 3 supporting packages: </li>
 </ul>
 


### PR DESCRIPTION
In setup a NOTE just after installing requirements it says "Windows users do not need to worry about his as these packages" I just changed his to this.
