### PR TITLE
Fixed typo in 'Setting up your computer'

### DIFF
--- a/website/_assets/pdfs/setup/mac-setup.md
+++ b/website/_assets/pdfs/setup/mac-setup.md
@@ -60,7 +60,7 @@ $ sudo pip install --upgrade setuptools
 
 <h5 style="text-align:center"><span style="color:#8c8c8c">virtualenv & virtualenvwrapper</span></h5>
 
-virtualenv\[9] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
+virtualenv\[9] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multiple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
 
 ```bash
 $ sudo pip install virtualenv

--- a/website/_containers/begin/2013-10-30-setup-your-machine.md
+++ b/website/_containers/begin/2013-10-30-setup-your-machine.md
@@ -72,7 +72,7 @@ $ sudo pip install --upgrade setuptools
 
 ### virtualenv & virtualenvwrapper
 
-[virtualenv][10] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
+[virtualenv][10] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multiple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
 
 ```bash
 $ sudo pip install virtualenv

--- a/website/_site/assets/pdfs/setup/mac-setup.md
+++ b/website/_site/assets/pdfs/setup/mac-setup.md
@@ -60,7 +60,7 @@ $ sudo pip install --upgrade setuptools
 
 <h5 style="text-align:center"><span style="color:#8c8c8c">virtualenv & virtualenvwrapper</span></h5>
 
-virtualenv\[9] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
+virtualenv\[9] creates isolated environments for each of your Python projects. It helps to solve version & dependency problems with multiple Python installations and/or multiple versions of different Python packages.  We’ll use `pip` to install it:
 
 ```bash
 $ sudo pip install virtualenv


### PR DESCRIPTION
'multiple' was misspelled as 'multple' in Mac OS X pip setup.