### PR TITLE
Update 2013-03-02-part-5.md

### DIFF
--- a/website/_containers/scrape/2013-03-02-part-5.md
+++ b/website/_containers/scrape/2013-03-02-part-5.md
@@ -70,7 +70,7 @@ Try a few of these select queries:
 
 ```psql
 scrape=# select title from deals limit 30;
-scrape=# select link from deals where price < 50;
+scrape=# select link from deals where price < '50';
 scrape=# select title from deals where end_date < '2015-02-08';
 scrape=# select * from deals where title like ('%Yoga');
 ```


### PR DESCRIPTION
Added quotes around the '50' as postgres will throw an error message otherwise ("HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.")