### PR TITLE
API tutorial - giantbomb API now requires user agent

### DIFF
--- a/apis/api.py
+++ b/apis/api.py
@@ -231,6 +231,7 @@ class GiantbombAPI(object):
             # certain number of items.
             params['offset'] = num_fetched_results
             result = requests.get(self.base_url + '/platforms/',
+                                  headers={'User-agent':'new-coder-tutorial'},
                                   params=params)
             result = result.json()
             if num_total_results is None:


### PR DESCRIPTION
Was taking a look at the API tutorial and kept getting 403 return when calling the giantbomb API. 
Googling uncovered this forum post from a month ago - http://www.giantbomb.com/forums/api-developers-3017/api-call-throws-error-403-forbidden-1496714/?page=1#js-message-8232912

Looks like giantbomb API now requires a (arbitrary) user agent. Adding this line fixes the 403.