### PR TITLE
dataviz: Ensure people try their package manager

### DIFF
--- a/website/_containers/dataviz/2013-01-05-part-0.md
+++ b/website/_containers/dataviz/2013-01-05-part-0.md
@@ -49,7 +49,9 @@ $ mkvirtualenv DataVizProj
 
 Sometimes, `matplotlib` is finicky as well. If you are on a Mac or Linux, and `pip install matplotlib` did not work, you are probably missing the supporting packages `zlib`, `freetype2` and `libpng`. Windows users do not need to worry about this as these packages are already included in the standard matplotlib Windows installers.
 
-To install (order of installation is important here):
+Before attempting to follow the instructions to compile these dependencies from source please use your package manager or its associated online package index to search for and install these dependencies instead. There usually exist pre-built packages for all these components on most [Linux](https://www.linode.com/docs/tools-reference/linux-package-management/) and BSD flavours as well as through macOS package managers [Homebrew](http://brew.sh) and [MacPorts](https://www.macports.org).
+
+To install from source (order of installation is important here):
 
 ### ZLIB
 


### PR DESCRIPTION
Though it's useful to include the from source installation instructions it is probably much easier for people to use their distribution's package manager instead.
