### PR TITLE
Add redirect rules for /About, /Contact

### DIFF
--- a/website/.htaccess
+++ b/website/.htaccess
@@ -3,7 +3,9 @@ RewriteCond %{HTTP_HOST} ^newcoder.io[nc]
 RewriteRule ^(.*)$ http://www.newcoder.io/$1 [r=301,nc]
 RedirectMatch 301 /~drafts/networks/(.*) /networks/$1
 RedirectMatch 301 /Begin/(.*) /begin/$1
+RedirectMatch 301 /About /about/
 RedirectMatch 301 /About/(.*) /about/$1
+RedirectMatch 301 /Contact /contact/
 RedirectMatch 301 /Contact/(.*) /contact/$1
 
 ErrorDocument 404 /404.html


### PR DESCRIPTION
There is a link to /Contact in the begin/how-to-work-through-tutorials page which currently 404s